### PR TITLE
Include the giter8 sbt plugin in the generated template.

### DIFF
--- a/src/main/g8/src/main/g8/project/giter8.sbt
+++ b/src/main/g8/src/main/g8/project/giter8.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "$giter8_version$")


### PR DESCRIPTION
As discussed in #10 the generated template can not be executed with sbt to run the tests as the giter8 plugin is missing from the generated template. This resolves the problem.