### PR TITLE
Updated .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ cache:
     - $HOME/.sbt/boot/
     - $HOME/.sbt/launchers
 
+# Tricks to avoid unnecessary cache updates
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
 jdk:
   - openjdk8
   - openjdk11
@@ -16,7 +22,3 @@ jdk:
 script:
   ## This runs the template with the default parameters, and runs test within the templated app.
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
-
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm

--- a/src/main/g8/.travis.yml
+++ b/src/main/g8/.travis.yml
@@ -7,13 +7,15 @@ cache:
     - $HOME/.sbt/boot/
     - $HOME/.sbt/launchers
 
+# Tricks to avoid unnecessary cache updates
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
 jdk:
   - oraclejdk8
 
 script:
   ## This runs the template with the default parameters, and runs test within the templated app.
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
-
-  # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" -exec rm {} \;
-  - find $HOME/.ivy2 -name "ivydata-*.properties" -exec rm {} \;

--- a/src/main/g8/.travis.yml
+++ b/src/main/g8/.travis.yml
@@ -15,5 +15,5 @@ script:
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M test
 
   # Tricks to avoid unnecessary cache updates
-  - find $HOME/.sbt -name "*.lock" | xargs rm
-  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+  - find $HOME/.sbt -name "*.lock" -exec rm {} \;
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -exec rm {} \;


### PR DESCRIPTION
find with xargs rm will fail if no file was found since this invokes rm with 0 parameters.
I have thus replaced it with a more robust `-exec rm {} \;`