### PR TITLE
Fixing g8Test

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -2,7 +2,6 @@
 // To test the template run `g8` or `g8Test` from the sbt session.
 // See https://www.foundweekends.org/giter8/testing.html#Using+the+Giter8Plugin for more details.
 lazy val root = (project in file("."))
-  .enablePlugins(ScriptedPlugin)
   .settings(
     name := "$name$",
     test in Test := {


### PR DESCRIPTION
As @performantdata noted in https://github.com/foundweekends/giter8/issues/860, some recent changes in sbt-scripted made `ScriptedPlugin` override the value of `scriptedDependencies` defined in the `Giter8Plugin`, making the `g8Test`ing step a no-op.

This small change fixes this behavior in the newly created templates created using this template, but the issue needs more attention.